### PR TITLE
Grammar correction

### DIFF
--- a/tutorials/password.html
+++ b/tutorials/password.html
@@ -24,7 +24,7 @@
       Edit on GitHub
     </a>
     <h3 id="type">Password cell type</h3>
-    <p>This kind of cell behaves like a text cell with a difference that it masks it's value using asterisk in cell renderer.
+    <p>This kind of cell behaves like a text cell with a difference that it masks its value using asterisk in cell renderer.
       For the cell editor, a <code>&lt;input type="password"&gt;</code> field is used. Data is stored in the data source as plain text.</p>
 
     <div data-jsfiddle="example1">


### PR DESCRIPTION
"It's" to "its" because possessive.