### PR TITLE
Fix dropdown selector

### DIFF
--- a/tutorials/dropdown.html
+++ b/tutorials/dropdown.html
@@ -46,11 +46,11 @@
             {type: 'numeric'},
             {
               type: 'dropdown',
-              source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white']
+              source: ['', 'yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white']
             },
             {
               type: 'dropdown',
-              source: ['yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white']
+              source: ['', 'yellow', 'red', 'orange', 'green', 'blue', 'gray', 'black', 'white']
             }
           ]
         });


### PR DESCRIPTION
It looks like the values that are permitted in the dropdown are those defined in the array. Somehow the default selection from dropdown ( first item) will populate the cell after you move away