### PR TITLE
Add a separator line example

### DIFF
--- a/tutorials/context-menu.html
+++ b/tutorials/context-menu.html
@@ -309,6 +309,10 @@
                   return this.getSelectedLast()[0] === 0; // `this` === hot3
                 }
               },
+              // A separator line can also be added like this:
+              // "sp1": { name: '---------' }
+              // and the key has to be unique
+              "sp1": '---------',
               "row_below": {
                 name: 'Click to add row below' // Set custom text for predefined option
               },


### PR DESCRIPTION
The documentation for adding a separator might be misleading. Add an example.

Relates to:
https://github.com/handsontable/docs/issues/16
https://github.com/handsontable/docs/issues/15
