### PR TITLE
Mention ruby and sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # API Documentation for Handsontable
 
 ## Installation
+
+Prerequisites: you need to have Ruby and Sass installed on your machine.
+
 Install the npm dependencies by typing:
 ```sh
 npm install


### PR DESCRIPTION
Include prerequisites in the README.

I wondered if we should also guide the user on how to install ruby&sass but this can become outdated quickly.