### PR TITLE
Fix the version of hot in the demo

### DIFF
--- a/tutorials/filtering.html
+++ b/tutorials/filtering.html
@@ -288,7 +288,7 @@
 
     <div class="codeLayout">
       <div class="buttons">
-        <button class="jsFiddleLink" data-runfiddle="example4" data-link="http://jsfiddle.net/vszLvxnL/1/">
+        <button class="jsFiddleLink" data-runfiddle="example4">
           <i class="fa fa-jsfiddle"></i>
           Edit in jsFiddle
         </button>


### PR DESCRIPTION
I removed the redirection to a specific link. Not sure it fixed the issue properly but locally it indeed pointed to `next`.