### PR TITLE
Add link to data sources

### DIFF
--- a/tutorials/data-binding.html
+++ b/tutorials/data-binding.html
@@ -10,7 +10,8 @@
     <div class="example-container clearfix" name="reference">
       <h3 id="page-reference">Understand binding as a reference</h3>
       <p>
-        Handsontable binds to your data source (list of arrays or list of objects) by reference (not by values,
+        Handsontable binds to your <a
+        href="/docs/<?js= version ?>/tutorial-data-sources.html">data source</a> (list of arrays or list of objects) by reference (not by values,
         we don't copy input dataset; we rely on the way how JavaScript handle objects). Therefore, all the data
         entered in the grid will alter the original data source.
 


### PR DESCRIPTION
### Context
Add a direct link between the data binding page and the data sources page.

### Types of changes
- [x] Improvement (better description, more examples etc.)

### Related issue(s):
1. https://github.com/handsontable/docs/issues/147