### PR TITLE
Add a note for the copy/paste tutorial about selection methods and their ability to focus Handsontable.

### DIFF
--- a/tutorials/copy-paste.html
+++ b/tutorials/copy-paste.html
@@ -115,6 +115,12 @@
           document.execCommand('cut');
         });
       </script>
+      <br>
+      <div class="notification info"><strong>Note: </strong> Not all selection-related Handsontable
+        methods result in it gaining focus. Make sure your table instance is focused by calling
+        <a href="./Core.html#isListening"><code>hot.isListening();</code></a>
+        before copying or pasting data.
+      </div>
     </div>
 
     <h4 id="copy-cut-hooks">Hooks</h4>


### PR DESCRIPTION
### Context
As [not all selection-related methods in Handsontable work the same in regards to Handsontable focus](https://github.com/handsontable/handsontable/issues/7290), I added information to the Copy/Paste tutorial about it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (any error in documentation i.e. wrong: wording, code, links, pictures, etc.)
- [x] Improvement (better description, more examples etc.)
- [ ] Misc (any other change)

### Related issue(s):
1. https://github.com/handsontable/handsontable/issues/7290