### PR TITLE
Add examples for wrappers - locales

### DIFF
--- a/static/scripts/jsfiddle-fixer.js
+++ b/static/scripts/jsfiddle-fixer.js
@@ -77,20 +77,31 @@
 
     } else if (key === 'handsontable-pro') {
       ns = 'Handsontable';
+
+    } else if (/^handsontable\/dist\/.+\.css$/.test(key)) { // ignore CSS imports
+      ns = '';
+
+    } else if (key === 'numbro') {
+      ns = 'numbro';
+
+    } else if (key === 'numbro/dist/languages.min.js') {
+      ns = 'numbro.allLanguages';
     }
 
     var moduleToReturn = window;
 
-    ns.split('.').forEach(function(n) {
-      moduleToReturn = moduleToReturn[n];
-    });
-
-    if (typeof moduleToReturn === 'undefined') {
-      moduleToReturn = window.exports;
-
+    if (ns !== '') {
       ns.split('.').forEach(function(n) {
         moduleToReturn = moduleToReturn[n];
       });
+
+      if (typeof moduleToReturn === 'undefined') {
+        moduleToReturn = window.exports;
+
+        ns.split('.').forEach(function(n) {
+          moduleToReturn = moduleToReturn[n];
+        });
+      }
     }
 
     return moduleToReturn;

--- a/static/scripts/jsfiddle-fixer.js
+++ b/static/scripts/jsfiddle-fixer.js
@@ -84,8 +84,13 @@
     } else if (key === 'numbro') {
       ns = 'numbro';
 
-    } else if (key === 'numbro/dist/languages.min.js') {
+    } else if (/^numbro\/dist\/languages\.min(\.js)?$/.test(key)) {
       ns = 'numbro.allLanguages';
+
+    } else if (/^numbro\/languages\/(.+)$/.test(key)) {
+      var match = key.match(/^numbro\/languages\/(.+)$/);
+
+      ns = 'numbro.allLanguages.' + match[1];
     }
 
     var moduleToReturn = window;

--- a/tutorials/tutorials.json
+++ b/tutorials/tutorials.json
@@ -355,7 +355,7 @@
           "wrapper-for-angular-custom-id": {
             "title": "Custom ID"
           },
-          "wrapper-for-vue-angular-up-a-locale": {
+          "wrapper-for-angular-setting-up-a-locale": {
             "title": "Setting up a locale"
           },
           "wrapper-for-angular-custom-context-menu-example": {

--- a/tutorials/tutorials.json
+++ b/tutorials/tutorials.json
@@ -319,6 +319,9 @@
           "wrapper-for-react-hot-column": {
             "title": "Using the HotColumn component"
           },
+          "wrapper-for-react-setting-up-a-locale": {
+            "title": "Setting up a locale"
+          },
           "wrapper-for-react-custom-context-menu-example": {
             "title": "Custom Context Menu example"
           },

--- a/tutorials/tutorials.json
+++ b/tutorials/tutorials.json
@@ -385,6 +385,9 @@
           "wrapper-for-vue-hot-column": {
             "title": "Using the hot-column component"
           },
+          "wrapper-for-vue-setting-up-a-locale": {
+            "title": "Setting up a locale"
+          },
           "wrapper-for-vue-custom-id-class-style": {
             "title": "Custom ID, Class, Style and other attributes"
           },

--- a/tutorials/tutorials.json
+++ b/tutorials/tutorials.json
@@ -355,6 +355,9 @@
           "wrapper-for-angular-custom-id": {
             "title": "Custom ID"
           },
+          "wrapper-for-vue-angular-up-a-locale": {
+            "title": "Setting up a locale"
+          },
           "wrapper-for-angular-custom-context-menu-example": {
             "title": "Custom Context Menu example"
           },

--- a/tutorials/wrapper-for-angular-setting-up-a-locale.html
+++ b/tutorials/wrapper-for-angular-setting-up-a-locale.html
@@ -20,27 +20,27 @@
       </div>
       <script type="text/typescript" data-jsfiddle="example1" data-jsfiddle-panel_js="4">
         // app.component.ts
-        import { Component } from "@angular/core";
-        import Handsontable from "handsontable";
-        import * as numbro from "numbro";
-        import * as languages from "numbro/dist/languages.min";
+        import { Component } from '@angular/core';
+        import Handsontable from 'handsontable';
+        import * as numbro from 'numbro';
+        import * as languages from 'numbro/dist/languages.min';
 
-        numbro.registerLanguage(languages["ja-JP"]);
-        numbro.registerLanguage(languages["tr-TR"]);
+        numbro.registerLanguage(languages['ja-JP']);
+        numbro.registerLanguage(languages['tr-TR']);
 
         // define formats
         const formatJP = {
-          pattern: "0,0.00 $",
-          culture: "ja-JP"
+          pattern: '0,0.00 $',
+          culture: 'ja-JP'
         };
 
         const formatTR = {
-          pattern: "0,0.00 $",
-          culture: "tr-TR"
+          pattern: '0,0.00 $',
+          culture: 'tr-TR'
         };
 
         @Component({
-          selector: "app-root",
+          selector: 'app-root',
           template: `
             <div>
               <hot-table class="hot" [data]="dataset" [colHeaders]="true">
@@ -69,13 +69,13 @@
           formatTR = formatTR;
           formatJP = formatJP;
           dataset: any[] = [
-            { productName: "Product A", JP_price: 1.32, TR_price: 100.56 },
+            { productName: 'Product A', JP_price: 1.32, TR_price: 100.56 },
             {
-              productName: "Product B",
+              productName: 'Product B',
               JP_price: 2.22,
               TR_price: 453.5
             },
-            { productName: "Product C", JP_price: 3.1, TR_price: 678.1 }
+            { productName: 'Product C', JP_price: 3.1, TR_price: 678.1 }
           ];
         }
 

--- a/tutorials/wrapper-for-angular-setting-up-a-locale.html
+++ b/tutorials/wrapper-for-angular-setting-up-a-locale.html
@@ -1,0 +1,106 @@
+<div class="static-content">
+  <div class="example-container clearfix">
+
+    <h3>
+      An example of Handsontable with locales setup in Angular.
+    </h3>
+    <div>
+      <app-root></app-root>
+    </div>
+    <script type="text/x-hot-html" data-jsfiddle="example1">
+      <app-root></app-root>
+    </script>
+
+    <div class="codeLayout">
+      <div class="buttons">
+        <button class="jsFiddleLink" data-runfiddle="example1">
+          <i class="fa fa-jsfiddle"></i>
+          Edit
+        </button>
+      </div>
+      <script type="text/typescript" data-jsfiddle="example1" data-jsfiddle-panel_js="4">
+        // app.component.ts
+        import { Component } from '@angular/core';
+        import Handsontable from 'handsontable';
+        import 'handsontable/languages/de-DE';
+
+        import numbro from "numbro";
+        import languages from "numbro/dist/languages.min";
+
+        numbro.registerLanguage(languages["ja-JP"]);
+        numbro.registerLanguage(languages["tr-TR"]);
+
+        numbro.setLanguage("ja-JP");
+        numbro.setLanguage("tr-TR");
+
+        // define formats
+        const formatJP = {
+          pattern: "0,0.00 $",
+          culture: "ja-JP"
+        };
+
+        const formatTR = {
+          pattern: "0,0.00 $",
+          culture: "tr-TR"
+        };
+
+        @Component({
+          selector: 'app-root',
+          template: `
+          <div>
+            <hot-table
+              class="hot"
+              [data]="dataset"
+              [colHeaders]="true"
+                <hot-column data="productName" [readOnly]="true" title="Product Name"></hot-column>
+                <hot-column data="JP_price" title="Price in Japan" type="numeric" numericFormat={formatJP}></hot-column>
+                <hot-column data="TR_price" title="Price in Turkey" type="numeric" numericFormat={formatTR}></hot-column>
+            </hot-table>
+          </div>
+          `,
+        })
+        class AppComponent {
+          dataset: any[] = [
+            {productName: "Product A", JP_price: 1.32, TR_price: 'Wall Street'},
+            {productName: "Product B", JP_price: 2.22, TR_price: 'Pennsylvania Avenue'},
+            {productName: "Product C", JP_price: 3.1, TR_price: 'Broadway'},
+          ];
+        }
+
+        // app.module.ts
+        import { NgModule } from '@angular/core';
+        import { BrowserModule } from '@angular/platform-browser';
+        import { HotTableModule } from '@handsontable/angular';
+
+        @NgModule({
+          imports:      [ BrowserModule, HotTableModule ],
+          declarations: [ AppComponent ],
+          bootstrap:    [ AppComponent ]
+        })
+        class AppModule { }
+
+        // bootstrap
+        import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
+        platformBrowserDynamic().bootstrapModule(AppModule).catch(err => { console.error(err) });</script>
+        <p>
+          The same example you can find <a href="https://stackblitz.com/edit/handsontable-angular" target="_blank">here</a>.
+        </p>
+    </div>
+  </div>
+    <p>
+      <a href="https://github.com/handsontable/docs/edit/<?js= version ?>/tutorials/wrapper-for-angular-examples.html"
+         class="edit-doc" target="_blank">Edit this page</a>
+    </p>
+</div>
+<script data-jsfiddle="common" src="/docs/<?js= env.opts.query.version ?>/scripts/jsfiddle-fixer.js"></script>
+<script data-jsfiddle="common" src="https://cdn.jsdelivr.net/npm/rxjs@6/bundles/rxjs.umd.js"></script>
+<script data-jsfiddle="common" src="https://cdn.jsdelivr.net/npm/core-js@2/client/core.min.js"></script>
+<script data-jsfiddle="common" src="https://cdn.jsdelivr.net/npm/zone.js@0.9/dist/zone.min.js"></script>
+<script data-jsfiddle="common" src="https://cdn.jsdelivr.net/npm/@angular/compiler@8/bundles/compiler.umd.min.js"></script>
+<script data-jsfiddle="common" src="https://cdn.jsdelivr.net/npm/@angular/core@8/bundles/core.umd.min.js"></script>
+<script data-jsfiddle="common" src="https://cdn.jsdelivr.net/npm/@angular/common@8/bundles/common.umd.min.js"></script>
+<script data-jsfiddle="common" src="https://cdn.jsdelivr.net/npm/@angular/platform-browser@8/bundles/platform-browser.umd.min.js"></script>
+<script data-jsfiddle="common" src="https://cdn.jsdelivr.net/npm/@angular/platform-browser-dynamic@8/bundles/platform-browser-dynamic.umd.min.js"></script>
+<script data-jsfiddle="common" src="https://cdn.jsdelivr.net/npm/@handsontable/angular@6.0.1/bundles/handsontable-angular.umd.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/typescript/3.4.5/typescript.min.js"></script>

--- a/tutorials/wrapper-for-angular-setting-up-a-locale.html
+++ b/tutorials/wrapper-for-angular-setting-up-a-locale.html
@@ -83,9 +83,6 @@
         import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
         platformBrowserDynamic().bootstrapModule(AppModule).catch(err => { console.error(err) });</script>
-        <p>
-          The same example you can find <a href="https://stackblitz.com/edit/handsontable-angular" target="_blank">here</a>.
-        </p>
     </div>
   </div>
     <p>

--- a/tutorials/wrapper-for-angular-setting-up-a-locale.html
+++ b/tutorials/wrapper-for-angular-setting-up-a-locale.html
@@ -20,17 +20,13 @@
       </div>
       <script type="text/typescript" data-jsfiddle="example1" data-jsfiddle-panel_js="4">
         // app.component.ts
-        import { Component } from '@angular/core';
-        import Handsontable from 'handsontable';
-
-        import numbro from "numbro";
-        import languages from "numbro/dist/languages.min";
+        import { Component } from "@angular/core";
+        import Handsontable from "handsontable";
+        import * as numbro from "numbro";
+        import * as languages from "numbro/dist/languages.min";
 
         numbro.registerLanguage(languages["ja-JP"]);
         numbro.registerLanguage(languages["tr-TR"]);
-
-        numbro.setLanguage("ja-JP");
-        numbro.setLanguage("tr-TR");
 
         // define formats
         const formatJP = {
@@ -44,25 +40,42 @@
         };
 
         @Component({
-          selector: 'app-root',
+          selector: "app-root",
           template: `
-          <div>
-            <hot-table
-              class="hot"
-              [data]="dataset"
-              [colHeaders]="true"
-                <hot-column data="productName" [readOnly]="true" title="Product Name"></hot-column>
-                <hot-column data="JP_price" title="Price in Japan" type="numeric" numericFormat={formatJP}></hot-column>
-                <hot-column data="TR_price" title="Price in Turkey" type="numeric" numericFormat={formatTR}></hot-column>
-            </hot-table>
-          </div>
-          `,
+            <div>
+              <hot-table class="hot" [data]="dataset" [colHeaders]="true">
+                <hot-column
+                  data="productName"
+                  [readOnly]="true"
+                  title="Product Name"
+                ></hot-column>
+                <hot-column
+                  data="JP_price"
+                  title="Price in Japan"
+                  type="numeric"
+                  [numericFormat]="formatJP"
+                ></hot-column>
+                <hot-column
+                  data="TR_price"
+                  title="Price in Turkey"
+                  type="numeric"
+                  [numericFormat]="formatTR"
+                ></hot-column>
+              </hot-table>
+            </div>
+          `
         })
         class AppComponent {
+          formatTR = formatTR;
+          formatJP = formatJP;
           dataset: any[] = [
-            {productName: "Product A", JP_price: 1.32, TR_price: 'Wall Street'},
-            {productName: "Product B", JP_price: 2.22, TR_price: 'Pennsylvania Avenue'},
-            {productName: "Product C", JP_price: 3.1, TR_price: 'Broadway'},
+            { productName: "Product A", JP_price: 1.32, TR_price: 100.56 },
+            {
+              productName: "Product B",
+              JP_price: 2.22,
+              TR_price: 453.5
+            },
+            { productName: "Product C", JP_price: 3.1, TR_price: 678.1 }
           ];
         }
 

--- a/tutorials/wrapper-for-angular-setting-up-a-locale.html
+++ b/tutorials/wrapper-for-angular-setting-up-a-locale.html
@@ -22,7 +22,6 @@
         // app.component.ts
         import { Component } from '@angular/core';
         import Handsontable from 'handsontable';
-        import 'handsontable/languages/de-DE';
 
         import numbro from "numbro";
         import languages from "numbro/dist/languages.min";

--- a/tutorials/wrapper-for-react-setting-up-a-locale.html
+++ b/tutorials/wrapper-for-react-setting-up-a-locale.html
@@ -1,0 +1,108 @@
+<div class="static-content">
+  <div class="example-container clearfix">
+
+    <h3>
+      An example of Handsontable with locales setup.
+    </h3>
+    <div data-jsfiddle="example1">
+      <div id="example1" class="hot"></div>
+    </div>
+
+    <div class="codeLayout">
+      <script type="text/html">
+        // a root div where the component is rendered
+        <div id="example1" class="hot"></div>
+      </script>
+    </div>
+
+    <div class="codeLayout">
+      <div class="buttons">
+        <button class="jsFiddleLink" data-runfiddle="example1">
+          <i class="fa fa-jsfiddle"></i>
+          Edit
+        </button>
+      </div>
+      <script type="text/jsx" data-jsfiddle="example1" data-jsfiddle-panel_js="3">
+        import React from "react";
+        import ReactDOM from "react-dom";
+        import Handsontable from 'handsontable';
+        import { HotTable, HotColumn } from "@handsontable/react";
+        import "handsontable/dist/handsontable.min.css";
+
+        import numbro from "numbro";
+        import languages from "numbro/dist/languages.min.js";
+
+        // register the languages you need
+        numbro.registerLanguage(languages["ja-JP"]);
+        numbro.registerLanguage(languages["tr-TR"]);
+
+        // define formats
+        const formatJP = {
+          pattern: "0,0.00 $",
+          culture: "ja-JP"
+        };
+
+        const formatTR = {
+          pattern: "0,0.00 $",
+          culture: "tr-TR"
+        };
+
+        class App extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              hotSettings: {
+                data: [
+                  {
+                    productName: "Product A",
+                    JP_price: 1.32,
+                    TR_price: 100.56
+                  },
+                  {
+                    productName: "Product B",
+                    JP_price: 2.22,
+                    TR_price: 453.5
+                  },
+                  {
+                    productName: "Product C",
+                    JP_price: 3.1,
+                    TR_price: 678.1
+                  }
+                ],
+                licenseKey: "non-commercial-and-evaluation",
+                autoRowSize: false,
+                autoColumnSize: false,
+                colHeaders: ["Product name", "Price in Japan", "Price in Turkey"]
+              }
+            };
+          }
+
+          render() {
+            return (
+              <HotTable settings={this.state.hotSettings}>
+                <HotColumn data="productName" type="text" width="120" />
+                <HotColumn
+                  data="JP_price"
+                  type="numeric"
+                  numericFormat={formatJP}
+                  width="120"
+                />
+                <HotColumn
+                  data="TR_price"
+                  type="numeric"
+                  numericFormat={formatTR}
+                  width="120"
+                />
+              </HotTable>
+            );
+          }
+        }
+
+        ReactDOM.render(<App />, document.getElementById('example1'));</script>
+    </div>
+</div>
+<script data-jsfiddle="common" src="/docs/<?js= env.opts.query.version ?>/scripts/jsfiddle-fixer.js"></script>
+<script data-jsfiddle="common" src="https://cdn.jsdelivr.net/npm/react@16/umd/react.development.js"></script>
+<script data-jsfiddle="common" src="https://cdn.jsdelivr.net/npm/react-dom@16/umd/react-dom.development.js"></script>
+<script data-jsfiddle="common" src="https://cdn.jsdelivr.net/npm/@handsontable/react@4.0.0/dist/react-handsontable.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@babel/standalone@7/babel.min.js"></script>

--- a/tutorials/wrapper-for-react-setting-up-a-locale.html
+++ b/tutorials/wrapper-for-react-setting-up-a-locale.html
@@ -3,7 +3,9 @@
   <div class="example-container clearfix">
 
     <h3>
-      An example of Handsontable with locales setup.
+      <p>
+      An example of Handsontable with locales setup in React.
+      </p>
     </h3>
     <div data-jsfiddle="example1">
       <div id="example1" class="hot"></div>

--- a/tutorials/wrapper-for-react-setting-up-a-locale.html
+++ b/tutorials/wrapper-for-react-setting-up-a-locale.html
@@ -41,12 +41,12 @@
 
         // define formats
         const formatJP = {
-          pattern: '0,0.00 $'',
+          pattern: '0,0.00 $',
           culture: 'ja-JP'
         };
 
         const formatTR = {
-          pattern: '0,0.00 $'',
+          pattern: '0,0.00 $',
           culture: 'tr-TR'
         };
 

--- a/tutorials/wrapper-for-react-setting-up-a-locale.html
+++ b/tutorials/wrapper-for-react-setting-up-a-locale.html
@@ -26,28 +26,28 @@
         </button>
       </div>
       <script type="text/jsx" data-jsfiddle="example1" data-jsfiddle-panel_js="3">
-        import React from "react";
-        import ReactDOM from "react-dom";
+        import React from 'react';
+        import ReactDOM from 'react-dom';
         import Handsontable from 'handsontable';
-        import { HotTable, HotColumn } from "@handsontable/react";
-        import "handsontable/dist/handsontable.min.css";
+        import { HotTable, HotColumn } from '@handsontable/react';
+        import 'handsontable/dist/handsontable.min.css';
 
-        import numbro from "numbro";
-        import languages from "numbro/dist/languages.min.js";
+        import numbro from 'numbro';
+        import languages from 'numbro/dist/languages.min.js';
 
         // register the languages you need
-        numbro.registerLanguage(languages["ja-JP"]);
-        numbro.registerLanguage(languages["tr-TR"]);
+        numbro.registerLanguage(languages['ja-JP']);
+        numbro.registerLanguage(languages['tr-TR']);
 
         // define formats
         const formatJP = {
-          pattern: "0,0.00 $",
-          culture: "ja-JP"
+          pattern: '0,0.00 $'',
+          culture: 'ja-JP'
         };
 
         const formatTR = {
-          pattern: "0,0.00 $",
-          culture: "tr-TR"
+          pattern: '0,0.00 $'',
+          culture: 'tr-TR'
         };
 
         class App extends React.Component {
@@ -57,25 +57,25 @@
               hotSettings: {
                 data: [
                   {
-                    productName: "Product A",
+                    productName: 'Product A',
                     JP_price: 1.32,
                     TR_price: 100.56
                   },
                   {
-                    productName: "Product B",
+                    productName: 'Product B',
                     JP_price: 2.22,
                     TR_price: 453.5
                   },
                   {
-                    productName: "Product C",
+                    productName: 'Product C',
                     JP_price: 3.1,
                     TR_price: 678.1
                   }
                 ],
-                licenseKey: "non-commercial-and-evaluation",
+                licenseKey: 'non-commercial-and-evaluation',
                 autoRowSize: false,
                 autoColumnSize: false,
-                colHeaders: ["Product name", "Price in Japan", "Price in Turkey"]
+                colHeaders: ['Product name', 'Price in Japan', 'Price in Turkey']
               }
             };
           }

--- a/tutorials/wrapper-for-react-setting-up-a-locale.html
+++ b/tutorials/wrapper-for-react-setting-up-a-locale.html
@@ -1,4 +1,5 @@
 <div class="static-content">
+  <script src="/docs/<?js= version ?>/components/numbro/dist/languages.min.js" data-jsfiddle="common"></script>
   <div class="example-container clearfix">
 
     <h3>

--- a/tutorials/wrapper-for-vue-setting-up-a-locale.html
+++ b/tutorials/wrapper-for-vue-setting-up-a-locale.html
@@ -55,7 +55,6 @@
         </hot-table>
       </div>
     </script>
-    <p>A <code>div</code> element of <code>id="example"</code> where the <code>@handsontable/vue</code> component will be rendered. HTML file:</p>
     <div class="codeLayout">
       <script type="text/html">
         <div id="example1" class="hot">
@@ -72,8 +71,8 @@
         </button>
       </div>
       <script type="text/babel" data-jsfiddle="example1" data-jsfiddle-panel_js="3">
+      import Vue from 'vue';
       import { HotTable, HotColumn } from "@handsontable/vue";
-
       import "handsontable/dist/handsontable.min.css";
       import numbro from "numbro";
       import languages from "numbro/dist/languages.min.js";

--- a/tutorials/wrapper-for-vue-setting-up-a-locale.html
+++ b/tutorials/wrapper-for-vue-setting-up-a-locale.html
@@ -1,0 +1,136 @@
+<div class="static-content">
+  <div class="example-container clearfix">
+    <h3>
+      <p>
+        An example of Handsontable with locales setup in Vue.
+      </p>
+    </h3>
+    <div>
+      <div id="example1">
+        <hot-table :data="hotData">
+          <hot-column
+            title="Product name"
+            data="productName"
+            width="120"
+          ></hot-column>
+          <hot-column
+            title="Price in Japan"
+            type="numeric"
+            :numericFormat="formatJP"
+            data="JP_price"
+            width="120"
+          ></hot-column>
+          <hot-column
+            title="Price in Turkey"
+            data="TR_price"
+            type="numeric"
+            :numericFormat="formatTR"
+            width="120"
+          ></hot-column>
+        </hot-table>
+      </div>
+    </div>
+    <script type="text/x-hot-html" data-jsfiddle="example1">
+      <div id="example1">
+        <hot-table :data="hotData">
+          <hot-column
+            title="Product name"
+            data="productName"
+            width="120"
+          ></hot-column>
+          <hot-column
+            title="Price in Japan"
+            type="numeric"
+            :numericFormat="formatJP"
+            data="JP_price"
+            width="120"
+          ></hot-column>
+          <hot-column
+            title="Price in Turkey"
+            data="TR_price"
+            type="numeric"
+            :numericFormat="formatTR"
+            width="120"
+          ></hot-column>
+        </hot-table>
+      </div>
+    </script>
+    <p>A <code>div</code> element of <code>id="example"</code> where the <code>@handsontable/vue</code> component will be rendered. HTML file:</p>
+    <div class="codeLayout">
+      <script type="text/html">
+        <div id="example1" class="hot">
+          <hot-table :settings="hotSettings"></hot-table>
+        </div>
+      </script>
+    </div>
+    <p>An implementation of the <code>@handsontable/vue</code> component. JS file:</p>
+    <div class="codeLayout">
+      <div class="buttons">
+        <button class="jsFiddleLink" data-runfiddle="example1">
+          <i class="fa fa-jsfiddle"></i>
+          Edit
+        </button>
+      </div>
+      <script type="text/babel" data-jsfiddle="example1" data-jsfiddle-panel_js="3">
+      import { HotTable, HotColumn } from "@handsontable/vue";
+
+      import "handsontable/dist/handsontable.min.css";
+      import numbro from "numbro";
+      import languages from "numbro/dist/languages.min.js";
+
+      // register needed languages
+      numbro.registerLanguage(languages["ja-JP"]);
+      numbro.registerLanguage(languages["tr-TR"]);
+
+      // define formats
+      const formatJP = {
+        pattern: "0,0.00 $",
+        culture: "ja-JP",
+      };
+
+      const formatTR = {
+        pattern: "0,0.00 $",
+        culture: "tr-TR",
+      };
+
+      new Vue({
+        el: '#example1',
+        data: function () {
+          return {
+            formatJP,
+            formatTR,
+            hotData: [
+              {
+                productName: "Product A",
+                JP_price: 1.32,
+                TR_price: 100.56,
+              },
+              {
+                productName: "Product B",
+                JP_price: 2.22,
+                TR_price: 453.5,
+              },
+              {
+                productName: "Product C",
+                JP_price: 3.1,
+                TR_price: 678.1,
+              },
+            ],
+          };
+        },
+      components: {
+        HotTable,
+        HotColumn,
+      },
+      });</script>
+    </div>
+  </div>
+    <p>
+      <a href="https://github.com/handsontable/docs/edit/<?js= version ?>/tutorials/wrapper-for-vue-setting-up-a-locale.html"
+         class="edit-doc" target="_blank">Edit this page</a>
+    </p>
+</div>
+<script data-jsfiddle="common" src="/docs/<?js= env.opts.query.version ?>/scripts/jsfiddle-fixer.js"></script>
+<script data-jsfiddle="common" src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.min.js"></script>
+<script data-jsfiddle="common" src="https://cdn.jsdelivr.net/npm/@handsontable/vue@5.1.0/dist/vue-handsontable.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@babel/standalone@7/babel.min.js"></script>

--- a/tutorials/wrapper-for-vue-setting-up-a-locale.html
+++ b/tutorials/wrapper-for-vue-setting-up-a-locale.html
@@ -72,24 +72,24 @@
       </div>
       <script type="text/babel" data-jsfiddle="example1" data-jsfiddle-panel_js="3">
       import Vue from 'vue';
-      import { HotTable, HotColumn } from "@handsontable/vue";
-      import "handsontable/dist/handsontable.min.css";
-      import numbro from "numbro";
-      import languages from "numbro/dist/languages.min.js";
+      import { HotTable, HotColumn } from '@handsontable/vue';
+      import 'handsontable/dist/handsontable.min.css';
+      import numbro from 'numbro';
+      import languages from 'numbro/dist/languages.min.js';
 
       // register needed languages
-      numbro.registerLanguage(languages["ja-JP"]);
-      numbro.registerLanguage(languages["tr-TR"]);
+      numbro.registerLanguage(languages['ja-JP']);
+      numbro.registerLanguage(languages['tr-TR']);
 
       // define formats
       const formatJP = {
-        pattern: "0,0.00 $",
-        culture: "ja-JP",
+        pattern: '0,0.00 $',
+        culture: 'ja-JP',
       };
 
       const formatTR = {
-        pattern: "0,0.00 $",
-        culture: "tr-TR",
+        pattern: '0,0.00 $',
+        culture: 'tr-TR',
       };
 
       new Vue({
@@ -100,17 +100,17 @@
             formatTR,
             hotData: [
               {
-                productName: "Product A",
+                productName: 'Product A',
                 JP_price: 1.32,
                 TR_price: 100.56,
               },
               {
-                productName: "Product B",
+                productName: 'Product B',
                 JP_price: 2.22,
                 TR_price: 453.5,
               },
               {
-                productName: "Product C",
+                productName: 'Product C',
                 JP_price: 3.1,
                 TR_price: 678.1,
               },


### PR DESCRIPTION
### Context
End-developers have trouble with setting up some locales for numeric fields (wrappers), give them some examples so they don't feel so lost.

### Types of changes
- [x] Improvement (better description, more examples etc.)

### Related issue(s):
1. https://github.com/handsontable/docs/issues/62