### PR TITLE
Correct the typo in copy paste plugin

### DIFF
--- a/tutorials/copy-paste.html
+++ b/tutorials/copy-paste.html
@@ -74,7 +74,7 @@
       <li><code>document.execCommand('copy')</code></li>
       <li><code>document.execCommand('cut')</code></li>
     </ul>
-    <p>The <i>CopyPaste</i> plugin listens to the browser's <code>cop</code> and <code>cut</code> events, so if they are triggered,
+    <p>The <i>CopyPaste</i> plugin listens to the browser's <code>copy</code> and <code>cut</code> events, so if they are triggered,
       our implementation will copy or cut the selected data into the system clipboard.</p>
     <div data-jsfiddle="example1">
       <p>


### PR DESCRIPTION
### Context
There was a typo! I corrected it.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (any error in documentation i.e. wrong: wording, code, links, pictures, etc.)

### Related issue(s):
1. https://github.com/handsontable/docs/issues/256
