### PR TITLE
Correct codeblocks styling

### DIFF
--- a/tutorials/modules.html
+++ b/tutorials/modules.html
@@ -48,9 +48,8 @@
      First, take a look at the settings, it is the same object in both cases:
     </p>
 
-<pre><code class="lang-js">
-const settings =  {
-  colHeaders: true,
+<pre><code class="lang-js">const settings = {
+colHeaders: true,
   filters: true,
   data: [
     {
@@ -83,28 +82,26 @@ const settings =  {
       source: ['Finland', 'France', 'Germany', 'Poland', 'United Kingdom'],
     },
   ]
-}
-    </code></pre>
+}</code></pre>
 
     <p>As you can see, very few plugins are used here: filtering and the dropdown.
       You can import a full bundle that contains all parts of Handsontable, including a variety of plugins:
     </p>
 
-    <pre><code class="lang-js">
-// import a full bundle, all functionalities included
+    <pre><code class="lang-js">// import a full bundle, all functionalities included
 import Handsontable from 'handsontable';
 
 const container = document.createElement('div');
 document.body.appendChild(container);
-const hot = new Handsontable(container, settings);
-    </code></pre>
+const hot = new Handsontable(container, settings);</code></pre>
+
     <p>
       However, this will load all plugins, also those that remain unused in the example.
       Thanks to using <strong>modules</strong> you can achieve the exactly same result but it will generate less KB.
       These steps decreased the final bundle to 200 KB (Gzipped):
     </p>
-    <pre><code class="lang-js">
-// import the base only
+
+    <pre><code class="lang-js">// import the base only
 import Handsontable from 'handsontable/base';
 // choose cell types you want to use and import them
 import { registerCellType, DropdownCellType } from 'handsontable/cellTypes';
@@ -126,9 +123,7 @@ registerPlugin(Filters);
 const container = document.createElement('div');
 document.body.appendChild(container);
 
-const hot = new Handsontable(container, settings);
-
-      </code></pre>
+const hot = new Handsontable(container, settings);</code></pre>
       <p>
         You can go even further and optimize <a href="#moment-js-optimize">moment.js locales</a> by excluding unnecessary localizations and decrease the final bundle of the example to 150 KB (Gzipped).
         Eventually, over 56% of the final bundle size was saved!
@@ -143,18 +138,17 @@ const hot = new Handsontable(container, settings);
         First, you need to import the <strong>base</strong> which contains the core elements of the component. Without them, Handsontable cannot be built
         at all:
       </p>
-        <pre><code class="lang-js">
-// this part is crucial to be imported
+
+        <pre><code class="lang-js">// this part is crucial to be imported
 import Handsontable from 'handsontable/base';
 
 // import the css file - this is not modularized;
-import 'handsontable/dist/handsontable.full.css';
-          </code></pre>
+import 'handsontable/dist/handsontable.full.css';</code></pre>
+
         <p>If you had already an import of Handsontable just remove this line:</p>
-          <pre><code class="lang-js">
-// you no longer need this import
-import Handsontable from "handsontable";
-          </code></pre>
+
+          <pre><code class="lang-js">// you no longer need this import
+import Handsontable from "handsontable";</code></pre>
         <p>The Handsontable <strong>base</strong> part includes:
         <ul>
           <li>moment.js</li>
@@ -188,21 +182,21 @@ import Handsontable from "handsontable";
         <p>
         Start with importing the base, <code>ContextMenu</code> and the <code>registerPlugin</code> method.
         </p>
-        <pre><code class="lang-js">
-// remember to have the base imported
+
+        <pre><code class="lang-js">// remember to have the base imported
 import Handsontable from 'handsontable/base';
 // import the method for registering a plugin
 // import the ContextMenu plugin
-import { registerPlugin, ContextMenu } from 'handsontable/plugins';
-        </code></pre>
+import { registerPlugin, ContextMenu } from 'handsontable/plugins';</code></pre>
+
         <p>Afterwards you need to use the <code>registerPlugin</code> method to register the <code>ContextMenu</code> plugin:</p>
-        <pre><code class="lang-js">
-// register the plugin before using it
-registerPlugin(ContextMenu);
-        </code></pre>
+
+        <pre><code class="lang-js">// register the plugin before using it
+registerPlugin(ContextMenu);</code></pre>
+
         <p>Now, you can use the <code>ContextMenu</code> plugin, the full example looks like this:</p>
-        <pre><code class="lang-js">
-import Handsontable from 'handsontable/base';
+
+        <pre><code class="lang-js">import Handsontable from 'handsontable/base';
 import { registerPlugin, AutoColumnSize, ContextMenu } from 'handsontable/plugins';
 
 registerPlugin(AutoColumnSize);
@@ -212,10 +206,10 @@ registerPlugin(ContextMenu);
 new Handsontable(container, {
   contextMenu: true,
   // rest of the settings
-});
-        </code></pre>
-        <p>And that is all! You can use the <code>ContextMenu</code> plugin.
-          </p>
+});</code></pre>
+
+        <p>And that is all! You can use the <code>ContextMenu</code> plugin.</p>
+
         </div>
         <div class="example-container clearfix">
           <h3 id="importing-editors">Importing editors</h3>
@@ -223,21 +217,21 @@ new Handsontable(container, {
             To use a specific editor you need to import it alongside the registering method. For instance, let's try adding the password editor.
           </p>
           <p>Start with importing the base, <code>PasswordEditor</code> and the <code>registerEditor</code> method.</p>
-            <pre><code class="lang-js">
-// remember to have the base imported
+
+            <pre><code class="lang-js">// remember to have the base imported
 import Handsontable from 'handsontable/base';
 // import the method for registering an editor
 // import the PasswordEditor
-import { registerEditor, PasswordEditor } from 'handsontable/editors';
-        </code></pre>
+import { registerEditor, PasswordEditor } from 'handsontable/editors';</code></pre>
+
         <p>Afterwards you need to use the <code>registerEditor</code> method to register <code>PasswordEditor</code>: </p>
-        <pre><code class="lang-js">
-// register the editor before using it
-registerEditor(PasswordEditor);
-        </code></pre>
+
+        <pre><code class="lang-js">// register the editor before using it
+registerEditor(PasswordEditor);</code></pre>
+
         <p>Now, you can use <code>PasswordEditor</code>, the full example looks like this:</p>
-        <pre><code class="lang-js">
-import Handsontable from 'handsontable/base';
+
+        <pre><code class="lang-js">import Handsontable from 'handsontable/base';
 import { registerEditor, PasswordEditor } from 'handsontable/editors';
 
 registerEditor(PasswordEditor);
@@ -250,8 +244,8 @@ new Handsontable(container, {
     },
   ]
   // rest of the settings
-});
-            </code></pre>
+});</code></pre>
+
             <p>And that is all! You can use the password editor!</p>
 
         </div>
@@ -262,21 +256,21 @@ new Handsontable(container, {
         To use a specific renderer you need to import it alongside the registering method. For instance, let's try adding the autocomplete renderer.
       </p>
       <p>Start with importing the base, <code>autocompleteRenderer</code> and the <code>registerRenderer</code> method.</p>
-        <pre><code class="lang-js">
-// remember to have the base imported
+
+        <pre><code class="lang-js">// remember to have the base imported
 import Handsontable from 'handsontable/base';
 // import the method for registering a renderer
 // import the autocompleteRenderer
-import { registerRenderer, autocompleteRenderer } from 'handsontable/renderers';
-    </code></pre>
+import { registerRenderer, autocompleteRenderer } from 'handsontable/renderers';</code></pre>
+
     <p>Afterwards you need to use the <code>registerRenderer</code> method to register <code>autocompleteRenderer</code>:</p>
-    <pre><code class="lang-js">
-// register the renderer before using it
-registerRenderer(autocompleteRenderer);
-    </code></pre>
+
+    <pre><code class="lang-js">// register the renderer before using it
+registerRenderer(autocompleteRenderer);</code></pre>
+
     <p>Now, you can use <code>autocompleteRenderer</code>, the full example looks like this:</p>
-    <pre><code class="lang-js">
-import Handsontable from 'handsontable/base';
+
+    <pre><code class="lang-js">import Handsontable from 'handsontable/base';
 import { registerRenderer, autocompleteRenderer } from 'handsontable/renderers';
 
 registerRenderer(autocompleteRenderer);
@@ -289,8 +283,8 @@ new Handsontable(container, {
     },
   ],
 // rest of the settings
-});
-        </code></pre>
+});</code></pre>
+
         <p>And that is all! You can use the autocomplete renderer!</p>
         </div>
         <div class="example-container clearfix">
@@ -299,22 +293,22 @@ new Handsontable(container, {
             To use a specific validator you need to import it alongside the registering method. For instance, let's try adding the numeric validator.
           </p>
           <p>Start with importing the base, <code>numericValidator</code> and the <code>registerValidator</code> method.</p>
-            <pre><code class="lang-js">
-// remember to have the base imported
+
+            <pre><code class="lang-js">// remember to have the base imported
 import Handsontable from 'handsontable/base';
 
 // import the method for registering a validator
 // import the numericValidator
-import { registerValidator, numericValidator } from 'handsontable/validators';
-    </code></pre>
+import { registerValidator, numericValidator } from 'handsontable/validators';</code></pre>
+
     <p>Afterwards you need to use the <code>registerValidator</code> method to register <code>numericValidator</code>:</p>
-    <pre><code class="lang-js">
-// register the validator before using it
-registerValidator(numericValidator);
-    </code></pre>
+
+    <pre><code class="lang-js">// register the validator before using it
+registerValidator(numericValidator);</code></pre>
+
     <p>Now, you can use <code>numericValidator</code>, the full example looks like this:</p>
-    <pre><code class="lang-js">
-import Handsontable from 'handsontable/base';
+
+    <pre><code class="lang-js">import Handsontable from 'handsontable/base';
 import { registerValidator, numericValidator } from 'handsontable/validators';
 
 registerValidator(numericValidator);
@@ -327,8 +321,8 @@ new Handsontable(container, {
     },
   ]
 // rest of the settings
-});
-            </code></pre>
+});</code></pre>
+
             <p>And that is all! You can use the numeric validator!</p>
         </div>
         <div class="example-container clearfix">
@@ -337,21 +331,20 @@ new Handsontable(container, {
                 To use a specific cell type you need to import it alongside the registering method. Let's try adding the checkbox cell type.
               </p>
               <p>Start with importing the base, <code>CheckboxCellType</code> and the <code>registerCellType</code> method.</p>
-                <pre><code class="lang-js">
-// remember to have the base imported
+                <pre><code class="lang-js">// remember to have the base imported
 import Handsontable from 'handsontable/base';
 // import the method for registering a cell type
 // import the CheckboxCellType
-import { registerCellType, CheckboxCellType } from 'handsontable/cellTypes';
-    </code></pre>
+import { registerCellType, CheckboxCellType } from 'handsontable/cellTypes';</code></pre>
+
     <p>Afterwards you need to use the <code>registerCellType</code> method to register <code>CheckboxCellType</code>:</p>
-    <pre><code class="lang-js">
-// register the cell type before using it
-registerCellType(CheckboxCellType);
-    </code></pre>
+
+    <pre><code class="lang-js">// register the cell type before using it
+registerCellType(CheckboxCellType);</code></pre>
+
     <p>Now, you can use <code>CheckboxCellType</code>, the full example looks like this:</p>
-    <pre><code class="lang-js">
-import Handsontable from 'handsontable/base';
+
+    <pre><code class="lang-js">import Handsontable from 'handsontable/base';
 import { registerCellType, CheckboxCellType } from 'handsontable/cellTypes';
 
 registerCellType(CheckboxCellType);
@@ -364,8 +357,8 @@ new Handsontable(container, {
     },
   ]
 // rest of the settings
-});
-                </code></pre>
+});</code></pre>
+
                 <p>And that is all! You can use the checkbox cell type!</p>
         </div>
         <div class="example-container clearfix">
@@ -374,23 +367,23 @@ new Handsontable(container, {
                     Importing locales works slightly different than in case of other elements. Let's try adding the <code>pl-PL</code> locale.
                   </p>
                   <p>Start with importing the base and the language code:</p>
-                    <pre><code class="lang-js">
-// remember to have the base imported
+
+                    <pre><code class="lang-js">// remember to have the base imported
 import Handsontable from 'handsontable/base';
 
 // import the language code
 import { plPL } from 'handsontable/i18n/languages';
 
 // and interface to register language
-import { registerLanguageDictionary } from 'handsontable/i18n';
-    </code></pre>
+import { registerLanguageDictionary } from 'handsontable/i18n';</code></pre>
+
     <p>Afterwards you need to register it:</p>
-    <pre><code class="lang-js">
-registerLanguageDictionary(plPL.languageCode, plPL);
-    </code></pre>
+
+    <pre><code class="lang-js">registerLanguageDictionary(plPL.languageCode, plPL);</code></pre>
+
     <p>Now, you can use newly registered locale. The full example looks like this:</p>
-    <pre><code class="lang-js">
-import Handsontable from 'handsontable/base';
+
+    <pre><code class="lang-js">import Handsontable from 'handsontable/base';
 import { registerLanguageDictionary } from 'handsontable/i18n';
 import { plPL } from 'handsontable/i18n/languages';
 
@@ -400,9 +393,10 @@ registerLanguageDictionary(plPL);
 new Handsontable(container, {
   language: 'pl-PL',
 // rest of the settings
-});
-                    </code></pre>
-                    <p>And that is all! You can use the PL-pl locale!</p>
+});</code></pre>
+
+    <p>And that is all! You can use the PL-pl locale!</p>
+
   </div>
 
   <div class="example-container clearfix">
@@ -412,19 +406,19 @@ new Handsontable(container, {
       <a href="https://github.com/jmblog/how-to-optimize-momentjs-with-webpack">this tutorial</a> directly.</p>
       <p>Moment.js can be heavyweight because when you type <code>var moment = require('moment')</code> in the code you get all locales as default.
       To be more selective with your choice you can first, use the <code>IgnorePlugin</code> that removes all locales:</p>
-      <pre><code class="lang-js">
-const webpack = require('webpack');
+
+      <pre><code class="lang-js">const webpack = require('webpack');
 module.exports = {
   //...
   plugins: [
     // Ignore all locale files of moment.js
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
   ],
-};
-        </code></pre>
+};</code></pre>
+
         <p>And then explicitly load selected locales:</p>
-        <pre><code class="lang-js">
-import moment from 'moment';
+
+        <pre><code class="lang-js">import moment from 'moment';
 import 'moment/locale/ja';
 import Handsontable from 'handsontable/base';
 import { registerCellType, DateCellType } from 'handsontable/cellTypes';
@@ -434,10 +428,8 @@ registerCellType(DateCellType);
 
 new Handsontable(container, {
   type: 'date',
-});
-          </code></pre>
+});</code></pre>
     </p>
-
   </div>
 
   <div class="example-container clearfix">
@@ -458,21 +450,21 @@ new Handsontable(container, {
       For the Webpack 3 and older, Parcel, and few other bundlers, those load CommonJS modules, three shaking might not work as presented above.
       For the modules to be imported correctly you need to split them and import them one by one from their respective files, just like this:
     <p>
-    <pre><code class="lang-js">
-// import the registering method directly from the file
+
+    <pre><code class="lang-js">// import the registering method directly from the file
 import { registerPlugin } from 'handsontable/plugins/registry';
 
 // import the plugins you need
 import { DropdownMenu } from 'handsontable/plugins/dropdownMenu';
-import { ContextMenu } from 'handsontable/plugins/contextMenu';
-    </code></pre>
+import { ContextMenu } from 'handsontable/plugins/contextMenu';</code></pre>
+
     <p>The list below presents all registering methods and their files of origin alongside all parts of the component
       to be imported.
     </p>
+
     <details>
       <summary>See the full list</summary>
-      <pre><code class="lang-js">
-import { registerEditor } from 'handsontable/editors/registry';
+      <pre><code class="lang-js">import { registerEditor } from 'handsontable/editors/registry';
 import { AutocompleteEditor } from 'handsontable/editors/autocompleteEditor';
 import { BaseEditor } from 'handsontable/editors/baseEditor';
 import { CheckboxEditor } from 'handsontable/editors/checkboxEditor';
@@ -543,8 +535,7 @@ import { registerValidator } from 'handsontable/validators/registry';
 import { autocompleteValidator } from 'handsontable/validators/autocompleteValidator';
 import { dateValidator } from 'handsontable/validators/dateValidator';
 import { numericValidator } from 'handsontable/validators/numericValidator';
-import { timeValidator } from 'handsontable/validators/timeValidator';
-    </code></pre>
+import { timeValidator } from 'handsontable/validators/timeValidator';</code></pre>
     </details>
   </div>
 
@@ -553,8 +544,7 @@ import { timeValidator } from 'handsontable/validators/timeValidator';
     <p>Here is an extensive list of all Handsontable parts imported and registered. This example builds Handsontable out of all fragments. You can copy and paste
       the ones you need.
     </p>
-    <pre><code class="lang-js">
-import Handsontable from 'handsontable/base';
+    <pre><code class="lang-js">import Handsontable from 'handsontable/base';
 import {
   registerEditor,
   AutocompleteEditor,
@@ -717,8 +707,7 @@ registerPlugin(TouchScroll);
 registerPlugin(TrimRows);
 registerPlugin(UndoRedo);
 
-new Handsontable(container, {});
-</code></pre>
+new Handsontable(container, {});</code></pre>
   </div>
 
   <p class="gap-top-xsmall">

--- a/tutorials/modules.html
+++ b/tutorials/modules.html
@@ -372,19 +372,19 @@ new Handsontable(container, {
 import Handsontable from 'handsontable/base';
 
 // import the language code and interface to register language
-import { registerLanguageDictionary, plPL } from 'handsontable/i18n';
-    </code></pre>
+import { registerLanguageDictionary, plPL } from 'handsontable/i18n';</code></pre>
+
     <p>Afterwards you need to register it:</p>
-    <pre><code class="lang-js">
-registerLanguageDictionary(plPL.languageCode, plPL);
+
+    <pre><code class="lang-js">registerLanguageDictionary(plPL.languageCode, plPL);
 
 // or if the language dictionary object contains the "languageCode" property,
 // the registration can be simplified to something like this
-registerLanguageDictionary(plPL);
-    </code></pre>
+registerLanguageDictionary(plPL);</code></pre>
+
     <p>Now, you can use newly registered locale. The full example looks like this:</p>
-    <pre><code class="lang-js">
-import Handsontable from 'handsontable/base';
+
+    <pre><code class="lang-js">import Handsontable from 'handsontable/base';
 import { registerLanguageDictionary, plPL } from 'handsontable/i18n';
 
 registerLanguageDictionary(plPL);

--- a/tutorials/modules.html
+++ b/tutorials/modules.html
@@ -537,8 +537,7 @@ import { dateValidator } from 'handsontable/validators/dateValidator';
 import { numericValidator } from 'handsontable/validators/numericValidator';
 import { timeValidator } from 'handsontable/validators/timeValidator';
 
-import { registerLanguageDictionary } from 'handsontable/i18n/registry';
-    </code></pre>
+import { registerLanguageDictionary } from 'handsontable/i18n/registry';</code></pre>
     </details>
   </div>
 

--- a/tutorials/suspend-rendering.html
+++ b/tutorials/suspend-rendering.html
@@ -36,18 +36,16 @@
       them inside the batch callback each single operation would end with a <code>render</code>. Thanks to the batching feature you can skip two renders and end the whole
       action with one render at the end. This is more optimal, and the gain grows with the number of operations placed inside the <code>batch</code>.
     </p>
-      <pre>
-        <code class="lang-js">
-// call the method on an instance
+
+      <pre><code class="lang-js">// call the method on an instance
 hot.batch(() => {
   // run the operations as needed
   hot.alter('insert_row', 5, 45);
   hot.setDataAtCell(1, 1, 'x');
   hot.selectCell(0, 0);
   // the render is executed right after all of the operations are completed
-});
-        </code>
-      </pre>
+});</code></pre>
+
     <p>
       As mentioned - suspending the render results in better performance, this is especially visible for numerous operations batched.
       The diagram shows a comparison, the same operations were performed with (deep blue columns) and without the batch (light blue columns).
@@ -106,9 +104,9 @@ hot.batch(() => {
       <p><strong>batch</strong> </p>
       This method supsends both rendering and other operations.
       It is universal and especially useful if you want to batch multiple API calls within the application.
-      <pre>
-        <code class="lang-js">
-hot.batch(() => {
+    </p>
+
+      <pre><code class="lang-js">hot.batch(() => {
   hot.alter('insert_row', 5, 45);
   hot.setDataAtCell(1, 1, 'x');
 
@@ -118,46 +116,38 @@ hot.batch(() => {
   filters.filter();
   hot.getPlugin('columnSorting').sort({ column: 1, sortOrder: 'desc' });
   // The table cache will be recalculated and table render will be called once after executing the callback
-});
-        </code>
-      </pre>
+});</code></pre>
 
-    </p>
     <p>
       <p><strong>batchRender</strong> </p>
       The <code>batchRender</code> method is a callback function, excessive renders can be skipped by placing the API calls inside of it.
       The table will be rendered after executing the callback.
       It is less prone to errors as you don't have to remember about resuming the render.
       However, there is a drawback to this method: it doesn't support async operations.
-      <pre>
-        <code class="lang-js">
-hot.batchRender(() => {
+    </p>
+
+      <pre><code class="lang-js">hot.batchRender(() => {
   hot.alter('insert_row', 5, 45);
   hot.setDataAtCell(1, 1, 'x');
   // The table will be rendered once after executing the callback
-});
-        </code>
-      </pre>
-  </p>
+});</code></pre>
+
   <p>
     <p><strong>batchExecution</strong> </p>
     The <code>batchExecution</code> is a callback function, excessive renders can be skipped by placing the API calls inside of it.
     The table will be rendered after executing the callback.
     It is less prone to errors as you don't have to remember about resuming the operations.
     However, there is a drawback to this method: it doesn't support async operations.
-    <pre>
-      <code class="lang-js">
-hot.batchExecution(() => {
+  </p>
+
+    <pre><code class="lang-js">hot.batchExecution(() => {
   const filters = hot.getPlugin('filters');
 
   filters.addCondition(2, 'contains', ['3']);
   filters.filter();
   hot.getPlugin('columnSorting').sort({ column: 1, sortOrder: 'desc' });
   // The table cache will be recalculated once after executing the callback
-});
-      </code>
-    </pre>
-  </p>
+});</code></pre>
 
   <h4>suspend* and resume* methods</h4>
 
@@ -166,31 +156,26 @@ hot.batchExecution(() => {
       <br>
       To suspend the rendering process you can use <code>suspendRender</code> method just before the actions you want to batch.
       This is a manual approach - after suspending you have to remember to resume the process with the <code>resumeRender</code> method.
-      <pre>
-        <code class="lang-js">
-hot.suspendRender(); // suspend rendering
+    </p>
+
+      <pre><code class="lang-js">hot.suspendRender(); // suspend rendering
 hot.alter('insert_row', 5, 45);
 hot.setDataAtCell(1, 1, 'x');
-hot.resumeRender(); // remember to resume rendering
-        </code>
-      </pre>
-    </p>
+hot.resumeRender(); // remember to resume rendering</code></pre>
 
     <p>
       <p><strong>suspendExecution</strong> and <strong>resumeExecution</strong></p>
       To suspend the rendering process you can use <code>suspendExecution</code> method just before the actions you want to batch.
       This is a manual approach - after suspending you have to remember to resume the process with the <code>resumeExecution</code> method.
-      <pre>
-        <code class="lang-js">
-hot.suspendExecution();
+    </p>
+
+      <pre><code class="lang-js">hot.suspendExecution();
 const filters = hot.getPlugin('filters');
 
 filters.addCondition(2, 'contains', ['3']);
 filters.filter();
 hot.getPlugin('columnSorting').sort({ column: 1, sortOrder: 'desc' });
-hot.resumeExecution(); // It updates the cache internally
-        </code>
-      </pre>
+hot.resumeExecution(); // It updates the cache internally</code></pre>
   </div>
 
   <div class="example-container clearfix" name="suspend-demo">


### PR DESCRIPTION
### Context
@aninde found out that the blocks with code on the "modules" and "suspend rendering pages" stand out (compared to other parts of the documentation). This PR makes them consistent.

The issue also mentions a problem with a gutter on the left side - this part looks consistent with the rest of the documentation so a `wontfix`.

### Types of changes
- [x] Misc (any other change)

### Related issue(s):
1. #284 
