### PR TITLE
Add additional description about testing frameworks

### DIFF
--- a/tutorials/testing.html
+++ b/tutorials/testing.html
@@ -47,6 +47,8 @@
       The wrappers contain their own framework-specific testing environments. You can either run the <code>npm
       run test</code> script inside of the wrapper directory, or utilize the <code>npm run in</code>/<code>npm
       run all</code> scripts to run the tests from the root.
+      <p class="notification info">Keep in mind that running wrapper tests require building the Handsontable (
+        <code>npm run build</code>). Once built the wrapper can consume its main dependency. Otherwise, tests will fail.</p>
     </p>
   </div>
   <div class="example-container clearfix">


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
Add an additional description about testing frameworks where `npm run build` is necessary to run before testing.

![image](https://user-images.githubusercontent.com/571316/110797681-9fe26480-8279-11eb-8f85-9ecf40868e2b.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (any error in documentation i.e. wrong: wording, code, links, pictures, etc.)
- [x] Improvement (better description, more examples etc.)
- [ ] Misc (any other change)

### Related issue(s):
1.
2.
3.
<!--- Remember to sign our CLA so we can accept your changes  -->
<!--- https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1  -->