### PR TITLE
Changed a typo in the tutorial intro

### DIFF
--- a/tutorials/cell-types.html
+++ b/tutorials/cell-types.html
@@ -1,4 +1,5 @@
 <div class="static-content">
+  <script src="/docs/<?js= version ?>/components/numbro/dist/languages.min.js" data-jsfiddle="common"></script>
 
   <div class="index-list">
 
@@ -6,6 +7,7 @@
       <li><a href="#page-registering-cell-type">Registering a cell type</a></li>
       <li><a href="#page-preview">Preview of built-in and custom cell types</a></li>
       <li><a href="#page-anatomy">Anatomy of a cell type</a></li>
+      <li><a href="#empty-cells">Empty cells</a></li>
     </ul>
   </div>
 
@@ -231,6 +233,69 @@
       <a href="https://github.com/handsontable/handsontable/blob/master/src/cellTypes" target="_blank">src/cellTypes/</a>
     </p>
   </div>
+
+  <div class="example-container clearfix" name="preview">
+    <h3 id="empty-cells">Empty cells</h3>
+    <p>Its worth to mention that values such as <code>''</code> (empty string), <code>null</code> and <code>undefined</code>
+      are considered empty values. You can use the <code>Handsontable.helper.isEmpty</code> method to check
+      whether a value is considered empty. Cells with empty values are displayed in a similar way for most of the data types
+      (see below).
+    </p>
+
+    <div data-jsfiddle="example2">
+      <div id="example2" class="hot"></div>
+    </div>
+
+    <script data-jsfiddle="example2">
+      var data = [
+        ['', 'Ford', 'Tesla', 'Toyota', 'Honda'],
+        ['2017', 10, 11, 12, 13],
+        ['2018', 20, 11, 14, 13],
+        ['2019', 30, 15, 12, 13]
+      ];
+
+      var container = document.getElementById('example2');
+      var hot = new Handsontable(container, {
+        data: [
+          ['empty string', '', '', '', '', ''],
+          ['null', null, null, null, null, null],
+          ['undefined', undefined, undefined, undefined, undefined, undefined],
+          ['non-empty value', 'non-empty text', 13000, true, 'orange', 'password'],
+        ],
+        columnSorting: {
+          sortEmptyCells: true
+        },
+        columns: [
+          {},
+          {},
+          {
+            type: 'numeric',
+            numericFormat: {
+              pattern: '$0,0.00',
+              culture: 'en-US' // this is the default culture, set up for USD
+            },
+          },
+          { type: 'checkbox' },
+          { type: 'dropdown', source: ['yellow', 'red', 'orange'] },
+          { type: 'password' },
+        ],
+        colHeaders: ['value<br>underneath', 'type:text', 'type:numeric', 'type:checkbox', 'type:dropdown', 'type:password'],
+      });
+    </script>
+
+    <p>Empty cells may be treated in differently in different contexts, for example, the <a href="/docs/<?js= version ?>/demo-sorting.html">ColumnSorting</a> plugin
+      has a <code>sortEmptyCells</code> option responsible for establishing whether empty cells should be sorted like non-empty cells.
+    </p>
+
+    <p>
+      <strong>Note:</strong> Please keep in mind that opening a cell with <code>undefined</code> and <code>null</code>
+      values results in <strong>overwriting</strong> the original value with an empty string.
+    </p>
+    <p>
+      <strong>Note:</strong> Please keep in mind that copying and pasting <code>undefined</code> and <code>null</code>
+      values will result in pasting the empty string.
+    </p>
+
   <p class="gap-top-xsmall">
     <a href="https://github.com/handsontable/docs/edit/<?js= version ?>/tutorials/cell-types.html" class="edit-doc" target="_blank">
       Edit this page

--- a/tutorials/multicolumn-sorting.html
+++ b/tutorials/multicolumn-sorting.html
@@ -191,18 +191,18 @@
 
         <script data-jsfiddle="example3" data-dont-display="true">
           var arrayOfObjects = [
-            { brand: "Tesla", model: "Model 3", maxSpeed: 141, range: 215, seats: 5, price: 32750, productionDate: "06/29/2007" },
-            { brand: "Tesla", model: "Model S", maxSpeed: 139, range: 275, seats: 7, price: 71788, productionDate: "04/02/2012" },
-            { brand: "Mitsubishi", model: "iMiEV", maxSpeed: 81, range: 99, seats: 4, price: 31426.9, productionDate: "09/11/2009" },
-            { brand: "Ford", model: "Focus EV", maxSpeed: 85, range: 100, seats: 4, price: 12000, productionDate: "10/01/2011" },
-            { brand: "Mitsubishi", model: "iMiEV Sport", maxSpeed: 84, range: 124, seats: 4, price: 15000, productionDate: "05/11/2007" },
-            { brand: "Tesla", model: "Roadster", maxSpeed: 125, range: 244, seats: 2, price: 113904.5, productionDate: "02/17/2008" },
-            { brand: "Volkswagen", model: "e-Golf", maxSpeed: 87, range: 118, seats: 5, price: 33012, productionDate: "10/05/2011" },
-            { brand: "Volkswagen", model: "E-Up!", maxSpeed: 85, range: 80, seats: 3, price: 32258.75, productionDate: "11/09/2009" },
-            { brand: "Ford", model: "C-Max Energi", maxSpeed: 115, range: 18, seats: 5, price: 27120, productionDate: "11/25/2014" },
-            { brand: "BYD", model: "Denza", maxSpeed: 93, range: 157, seats: 5, price: 47600, productionDate: "10/01/2011" },
-            { brand: "BYD", model: "e5", maxSpeed: 93, range: 136, seats: 5, price: 22966.92, productionDate: "07/19/2015" },
-            { brand: "BYD", model: "e6", maxSpeed: 87, range: 199, seats: 5, price: 31440, productionDate: "06/22/2009" }
+            { brand: "Tesla", model: "Model 3", maxSpeed: 141, range: 215, seats: 5, available: true, price: 32750, productionDate: "06/29/2007" },
+            { brand: "Tesla", model: "Model S", maxSpeed: 139, range: 275, seats: 7, available: false, price: 71788, productionDate: "04/02/2012" },
+            { brand: "Mitsubishi", model: "iMiEV", maxSpeed: 81, range: 99, seats: 4, available: true, price: 31426.9, productionDate: "09/11/2009" },
+            { brand: "Ford", model: "Focus EV", maxSpeed: 85, range: 100, seats: 4, available: true ,price: 12000, productionDate: "10/01/2011" },
+            { brand: "Mitsubishi", model: "iMiEV Sport", maxSpeed: 84, range: 124, seats: 4, available: false, price: 15000, productionDate: "05/11/2007" },
+            { brand: "Tesla", model: "Roadster", maxSpeed: 125, range: 244, seats: 2, available: false, price: 113904.5, productionDate: "02/17/2008" },
+            { brand: "Volkswagen", model: "e-Golf", maxSpeed: 87, range: 118, seats: 5, available: false, price: 33012, productionDate: "10/05/2011" },
+            { brand: "Volkswagen", model: "E-Up!", maxSpeed: 85, range: 80, seats: 3, available: true,price: 32258.75, productionDate: "11/09/2009" },
+            { brand: "Ford", model: "C-Max Energi", maxSpeed: 115, range: 18, seats: 5, available: false, price: 27120, productionDate: "11/25/2014" },
+            { brand: "BYD", model: "Denza", maxSpeed: 93, range: 157, seats: 5, available: false, price: 47600, productionDate: "10/01/2011" },
+            { brand: "BYD", model: "e5", maxSpeed: 93, range: 136, seats: 5, available: true,price: 22966.92, productionDate: "07/19/2015" },
+            { brand: "BYD", model: "e6", maxSpeed: 87, range: 199, seats: 5, available: false, price: 31440, productionDate: "06/22/2009" }
           ];
         </script>
 
@@ -210,7 +210,7 @@
           var exampleContainer3 = document.getElementById('example3');
           new Handsontable(exampleContainer3, {
             data: arrayOfObjects,
-            colHeaders: ["Brand", "Model", "Max speed<br>(in miles per hour)", "Range<br>(in miles)", "Seats", "Price", "Start of<br>production"],
+            colHeaders: ["Brand", "Model", "Max speed<br>(in miles per hour)", "Range<br>(in miles)", "Available", "Price", "Start of<br>production"],
             columns: [{
               data: 'brand' // 1st column is simple text, no special options here
             }, {
@@ -222,8 +222,8 @@
               data: 'range',
               type: 'numeric'
             }, {
-              data: 'seats',
-              type: 'numeric'
+              data: 'available',
+              type: 'checkbox'
             }, {
               data: 'price',
               type: 'numeric',

--- a/tutorials/nested-headers.html
+++ b/tutorials/nested-headers.html
@@ -12,7 +12,7 @@
 
     <h3 id="overview">Overview</h3>
     <p>
-      The <i>Nested Rows</i> plugin allows creating a nested header structure, using the <code>colspan</code> attribute.
+      The <i>Nested Headers</i> plugin allows creating a nested header structure, using the <code>colspan</code> attribute.
       <br><br>
       <strong>Note:</strong> the plugin supports a <i>nested</i> structure, which means that a header cannot be wider than its "parent" element. In other words, headers cannot overlap each other.
     </p>

--- a/tutorials/sorting.html
+++ b/tutorials/sorting.html
@@ -188,18 +188,18 @@
 
         <script data-jsfiddle="example3" data-dont-display="true">
           var arrayOfObjects = [
-            { brand: "Tesla", model: "Model 3", maxSpeed: 141, range: 215, seats: 5, price: 32750, productionDate: "06/29/2007" },
-            { brand: "Tesla", model: "Model S", maxSpeed: 139, range: 275, seats: 7, price: 71788, productionDate: "04/02/2012" },
-            { brand: "Mitsubishi", model: "iMiEV", maxSpeed: 81, range: 99, seats: 4, price: 31426.9, productionDate: "09/11/2009" },
-            { brand: "Ford", model: "Focus EV", maxSpeed: 85, range: 100, seats: 4, price: 12000, productionDate: "10/01/2011" },
-            { brand: "Mitsubishi", model: "iMiEV Sport", maxSpeed: 84, range: 124, seats: 4, price: 15000, productionDate: "05/11/2007" },
-            { brand: "Tesla", model: "Roadster", maxSpeed: 125, range: 244, seats: 2, price: 113904.5, productionDate: "02/17/2008" },
-            { brand: "Volkswagen", model: "e-Golf", maxSpeed: 87, range: 118, seats: 5, price: 33012, productionDate: "10/05/2011" },
-            { brand: "Volkswagen", model: "E-Up!", maxSpeed: 85, range: 80, seats: 3, price: 32258.75, productionDate: "11/09/2009" },
-            { brand: "Ford", model: "C-Max Energi", maxSpeed: 115, range: 18, seats: 5, price: 27120, productionDate: "11/25/2014" },
-            { brand: "BYD", model: "Denza", maxSpeed: 93, range: 157, seats: 5, price: 47600, productionDate: "10/01/2011" },
-            { brand: "BYD", model: "e5", maxSpeed: 93, range: 136, seats: 5, price: 22966.92, productionDate: "07/19/2015" },
-            { brand: "BYD", model: "e6", maxSpeed: 87, range: 199, seats: 5, price: 31440, productionDate: "06/22/2009" }
+            { brand: "Tesla", model: "Model 3", maxSpeed: 141, range: 215, seats: 5, available: true, price: 32750, productionDate: "06/29/2007" },
+            { brand: "Tesla", model: "Model S", maxSpeed: 139, range: 275, seats: 7, available: false, price: 71788, productionDate: "04/02/2012" },
+            { brand: "Mitsubishi", model: "iMiEV", maxSpeed: 81, range: 99, seats: 4, available: true, price: 31426.9, productionDate: "09/11/2009" },
+            { brand: "Ford", model: "Focus EV", maxSpeed: 85, range: 100, seats: 4, available: true ,price: 12000, productionDate: "10/01/2011" },
+            { brand: "Mitsubishi", model: "iMiEV Sport", maxSpeed: 84, range: 124, seats: 4, available: false, price: 15000, productionDate: "05/11/2007" },
+            { brand: "Tesla", model: "Roadster", maxSpeed: 125, range: 244, seats: 2, available: false, price: 113904.5, productionDate: "02/17/2008" },
+            { brand: "Volkswagen", model: "e-Golf", maxSpeed: 87, range: 118, seats: 5, available: false, price: 33012, productionDate: "10/05/2011" },
+            { brand: "Volkswagen", model: "E-Up!", maxSpeed: 85, range: 80, seats: 3, available: true,price: 32258.75, productionDate: "11/09/2009" },
+            { brand: "Ford", model: "C-Max Energi", maxSpeed: 115, range: 18, seats: 5, available: false, price: 27120, productionDate: "11/25/2014" },
+            { brand: "BYD", model: "Denza", maxSpeed: 93, range: 157, seats: 5, available: false, price: 47600, productionDate: "10/01/2011" },
+            { brand: "BYD", model: "e5", maxSpeed: 93, range: 136, seats: 5, available: true,price: 22966.92, productionDate: "07/19/2015" },
+            { brand: "BYD", model: "e6", maxSpeed: 87, range: 199, seats: 5, available: false, price: 31440, productionDate: "06/22/2009" }
           ];
         </script>
 
@@ -207,7 +207,7 @@
           var exampleContainer3 = document.getElementById('example3');
           new Handsontable(exampleContainer3, {
             data: arrayOfObjects,
-            colHeaders: ["Brand", "Model", "Max speed<br>(in miles per hour)", "Range<br>(in miles)", "Seats", "Price", "Start of<br>production"],
+            colHeaders: ["Brand", "Model", "Max speed<br>(in miles per hour)", "Range<br>(in miles)", "Available", "Price", "Start of<br>production"],
             columns: [{
               data: 'brand' // 1st column is simple text, no special options here
             }, {
@@ -219,8 +219,8 @@
               data: 'range',
               type: 'numeric'
             }, {
-              data: 'seats',
-              type: 'numeric'
+              data: 'available',
+              type: 'checkbox'
             }, {
               data: 'price',
               type: 'numeric',


### PR DESCRIPTION
I've changed the single typo in the 1st paragraph of the tutorial.

Changed from >Nested Rows to >Nested Headers.

### Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (any error in documentation i.e. wrong: wording, code, links, pictures, etc.)
- [ ] Improvement (better description, more examples etc.)
- [ ] Misc (any other change)

### Related issue(s):
1.
2.
3.
<!--- Remember to sign our CLA so we can accept your changes  -->
<!--- https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1  -->