### PR TITLE
Remove the `json-patch-duplex.js` entry

### DIFF
--- a/tutorials/licensing.html
+++ b/tutorials/licensing.html
@@ -53,12 +53,6 @@
                 <a href="https://github.com/handsontable/formula.js" target="_blank">https://github.com/handsontable/formula.js</a>
             </li>
             <li>
-                <strong>json-patch-duplex.js</strong> (implementation of JSON-Patch - RFC 6902)<br/>
-                Author: Starcounter<br/>
-                License: Open source (MIT)<br/>
-                <a href="https://github.com/Starcounter-Jack/JSON-Patch" target="_blank">https://github.com/Starcounter-Jack/JSON-Patch</a>
-            </li>
-            <li>
                 <strong>core-js</strong> (polyfills for ECMAScript 5, ECMAScript 6, promises, symbols, collections)<br/>
                 Author: Denis Pushkarev<br/>
                 License: Open source (MIT)<br/>

--- a/tutorials/licensing.html
+++ b/tutorials/licensing.html
@@ -29,6 +29,12 @@
         <h3>Third-party software components</h3>
         <ul>
             <li>
+                <strong>HyperFormula</strong> (provides logic for Formulas plugin)<br/>
+                Author: Handsontable<br/>
+                License: Open source (AGPL 3.0 or Commercial)<br/>
+                <a href="https://github.com/handsontable/hyperformula" target="_blank">https://github.com/handsontable/hyperformula</a>
+            </li>
+            <li>
                 <strong>numbro.js</strong> (handles numeric data)<br/>
                 Author: Benjamin Van Ryseghem<br/>
                 License: Open source (MIT)<br/>
@@ -47,40 +53,10 @@
                 <a href="http://momentjs.com" target="_blank">http://momentjs.com</a>
             </li>
             <li>
-                <strong>formula.js</strong> (provides syntax and logic for functions)<br/>
-                Author: Handsontable <br/>
-                License: Open source (MIT)<br/>
-                <a href="https://github.com/handsontable/formula.js" target="_blank">https://github.com/handsontable/formula.js</a>
-            </li>
-            <li>
                 <strong>core-js</strong> (polyfills for ECMAScript 5, ECMAScript 6, promises, symbols, collections)<br/>
                 Author: Denis Pushkarev<br/>
                 License: Open source (MIT)<br/>
                 <a href="https://github.com/zloirock/core-js" target="_blank">https://github.com/zloirock/core-js</a>
-            </li>
-            <li>
-                <strong>bessel</strong> (bessel functions in pure JS)<br/>
-                Author: SheetJS <br/>
-                License: Open source (Apache 2.0)<br/>
-                <a href="https://github.com/SheetJS/bessel" target="_blank">https://github.com/SheetJS/bessel</a>
-            </li>
-            <li>
-                <strong>jStat</strong> (statistical library)<br/>
-                Author: jStat <br/>
-                License: Open source (MIT)<br/>
-                <a href="https://github.com/jstat/jstat" target="_blank">https://github.com/jstat/jstat</a>
-            </li>
-            <li>
-                <strong>tiny-emitter</strong> (a tiny event emitter library)<br/>
-                Author: Scott Corgan <br/>
-                License: Open source (MIT)<br/>
-                <a href="https://github.com/scottcorgan/tiny-emitter" target="_blank">https://github.com/scottcorgan/tiny-emitter</a>
-            </li>
-            <li>
-                <strong>formula-parser</strong> (parsing excel formulas library)<br/>
-                Author: Handsontable <br/>
-                License: Open source (MIT)<br/>
-                <a href="https://github.com/handsontable/formula-parser" target="_blank">https://github.com/handsontable/formula-parser</a>
             </li>
             <li>
                 <strong>javascript-algorithms</strong> (implementation of linked list and merge sort)<br/>


### PR DESCRIPTION
### Context
<!--- Why is this change required? What problem does it solve? -->
The lib is removed within the PR (https://github.com/handsontable/handsontable/pull/8141).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (any error in documentation i.e. wrong: wording, code, links, pictures, etc.)
- [ ] Improvement (better description, more examples etc.)
- [ ] Misc (any other change)

### Related issue(s):
1. https://github.com/handsontable/handsontable/pull/8141
2.
3.
<!--- Remember to sign our CLA so we can accept your changes  -->
<!--- https://docs.google.com/forms/d/e/1FAIpQLScpMq4swMelvw3-onxC8Jl29m0fVp5hpf7d1yQVklqVjGjWGA/viewform?c=0&w=1  -->